### PR TITLE
feat(product): Add category creation on the fly

### DIFF
--- a/app/src/app/features/product/product-create/product-create.component.html
+++ b/app/src/app/features/product/product-create/product-create.component.html
@@ -20,15 +20,19 @@
     </mat-form-field>
   </div>
   <div>
-    <mat-form-field *ngIf="categories" appearance="fill">
-      <mat-label>Select</mat-label>
-      <mat-select formControlName="categories" multiple>
-        <div *ngFor="let categorie of categories$ | async">
-          <mat-option [value]="categorie._id">
-            {{categorie.name}}
-          </mat-option>
-        </div>
-      </mat-select>
+    <mat-form-field *ngIf="category" appearance="outline">
+      <mat-label>Category</mat-label>
+      <input type="text"
+             placeholder="Category"
+             aria-label="Category"
+             matInput
+             [formControl]="category"
+             [matAutocomplete]="auto">
+      <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
+        <mat-option [id]="category._id" *ngFor="let category of filteredCategories | async" [value]="category.name" (click)="onSelectCategory($event)">
+          {{ category.name }}
+        </mat-option>
+      </mat-autocomplete>
     </mat-form-field>
   </div>
   <div>

--- a/app/src/app/features/product/product-create/product-create.component.ts
+++ b/app/src/app/features/product/product-create/product-create.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 import { ICategory } from 'src/app/logic/interfaces/category.interface';
 import { CategoryService } from 'src/app/shared/services/category.service';
 import { ProductService } from 'src/app/shared/services/product.service';
 import { ProductFormBuilder } from './form/product.form';
+import { map, startWith, tap } from 'rxjs/operators';
+import { IProduct } from 'src/app/logic/interfaces/product.interface';
+import { category } from 'src/app/logic/class/category.class';
 
 @Component({
   selector: 'app-product-create',
@@ -12,7 +15,9 @@ import { ProductFormBuilder } from './form/product.form';
 })
 export class ProductCreateComponent implements OnInit {
   public form: FormGroup = new FormGroup({});
-  public categories$: Observable<ICategory[]> = this.categorieService.categories$;
+  public categories$: BehaviorSubject<ICategory[]> = this.categorieService.categories$;
+  public filteredCategories: Observable<ICategory[]>;
+  public selectedCategory?: ICategory = null;
 
   constructor(
     private productFormBuilder: ProductFormBuilder,
@@ -21,7 +26,27 @@ export class ProductCreateComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.form = this.productFormBuilder.build();
+    this.categorieService.init().pipe(
+      tap(() => this.filteredCategories = this.category.valueChanges.pipe(
+        startWith(''),
+        tap(() => this.selectedCategory = null), // Each time the category value change, we want to reset the selected category filter
+        map(value => this._filter(value || '')),
+      ))
+    ).subscribe();
+    this.form = this.productFormBuilder.build();    
+  }
+
+  private _filter(value: string): ICategory[] {
+    const filterValue = value.toLowerCase();
+    
+    return this.categorieService.categories$.value.filter(cat => cat.name.toLowerCase().includes(filterValue));
+  }
+
+  private onSelectCategory(event) {
+    let el = event.target as Element;
+    let category_id = el.parentElement.id;
+
+    this.selectedCategory = this.categories$.value.find(cat => cat._id == category_id);
   }
 
   get name(): AbstractControl|null {
@@ -32,8 +57,8 @@ export class ProductCreateComponent implements OnInit {
     return this.form.get('description');
   }
 
-  get categories(): AbstractControl|null {
-    return this.form.get('categories');
+  get category(): AbstractControl|null {
+    return this.form.get('category');
   }
 
   get price(): AbstractControl|null {
@@ -46,6 +71,16 @@ export class ProductCreateComponent implements OnInit {
       return null;
     }
 
-    this.productService.create(form.value);
+    let product: IProduct = form.value;    
+
+    if (!this.selectedCategory) {
+      // Create new category object
+      product = {...product, category: new category(form.value.category, '')}
+    } else {
+      // Use an existing category object
+      product = {...product, category: this.selectedCategory}
+    }
+    
+    this.productService.create(product);
   }
 }

--- a/app/src/app/shared/modules/material.module.ts
+++ b/app/src/app/shared/modules/material.module.ts
@@ -8,6 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatGridListModule } from '@angular/material/grid-list';
 import {MatChipsModule} from '@angular/material/chips';
 import { MatSelectModule } from '@angular/material/select'
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
 
 const MATERIALS = [
     MatInputModule
@@ -19,6 +20,7 @@ const MATERIALS = [
   , MatGridListModule
   , MatChipsModule
   , MatSelectModule
+  , MatAutocompleteModule
 ];
 
 @NgModule({

--- a/app/src/app/shared/services/category.service.ts
+++ b/app/src/app/shared/services/category.service.ts
@@ -12,9 +12,7 @@ const HTTP_API = '/api';
 export class CategoryService {
   public categories$: BehaviorSubject<ICategory[]> = new BehaviorSubject(null);
 
-  constructor(private http: HttpClient) {
-      this.init().subscribe()
-  }
+  constructor(private http: HttpClient) {}
 
   public init(): Observable<ICategory[]> {
     return this.http.get<ICategory[]>(`${HTTP_API}/categories/search`)
@@ -23,5 +21,10 @@ export class CategoryService {
             this.categories$.next(categories);
           })
         );
+  }
+
+  public create(category: string): void
+  {
+    this.http.post(`${HTTP_API}/categories/create`, {name: category});
   }
 }


### PR DESCRIPTION
- Add a new 'category' fields on the product form so we can easyli add/create a category to the created product.


![display_new_feature_category](https://user-images.githubusercontent.com/22416140/233212942-06398b83-cd86-45ee-a1b8-50bf67ac134e.gif)
